### PR TITLE
feat(manifest): return content

### DIFF
--- a/manifestservice/manifests/__init__.py
+++ b/manifestservice/manifests/__init__.py
@@ -73,13 +73,9 @@ def get_manifest_file(file_name):
 
     folder_name = _get_folder_name_from_token(current_token)
 
-    json_to_return = {
-        "body": _get_file_contents(
+    return _get_file_contents(
             flask.current_app.config.get("MANIFEST_BUCKET_NAME"), folder_name, file_name
         )
-    }
-
-    return flask.jsonify(json_to_return), 200
 
 
 @blueprint.route("/", methods=["PUT", "POST"])


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- make /file/<manifestname> return the raw content of the manifest so it doesn't need extra parsing to let gen3fuse read it

### Dependency updates


### Deployment changes

