### PR TITLE
feat(IAM-SA): Removed AKID references to use IAM SA role instead

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2020-10-19T22:23:04Z",
+  "generated_at": "2023-05-22T19:12:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -57,16 +57,7 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {
-    "config.json": [
-      {
-        "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
-        "is_verified": false,
-        "line_number": 3,
-        "type": "Secret Keyword"
-      }
-    ]
-  },
+  "results": {},
   "version": "0.13.1",
   "word_list": {
     "file": null,

--- a/config.json
+++ b/config.json
@@ -1,6 +1,4 @@
 {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": "",
     "manifest_bucket_name" : "",
     "hostname": "",
     "prefix": ""

--- a/docs/credentials_breaking_change.md
+++ b/docs/credentials_breaking_change.md
@@ -10,7 +10,7 @@ Historically, the ManifestService required AWS credentials to be able to access 
 
 ## New Method
 
-With the latest update, ManifestService will no longer look for AWS credentials in the configuration file. Instead, the service will rely on credentials mounted to the pod. This change is implemented to ensure an improved security environment for the service.
+Starting in version 1.0.0/2023.07, ManifestService longer looks for AWS credentials in the configuration file. Instead, the service relies on credentials mounted to the pod. This change is implemented to ensure an improved security environment for the service.
 
 ### AWS EKS IRSA
 

--- a/docs/credentials_breaking_change.md
+++ b/docs/credentials_breaking_change.md
@@ -1,0 +1,29 @@
+# Breaking Change to ManifestService
+
+## Summary
+
+We are introducing a significant update to ManifestService, which currently acts as a proxy to an Amazon S3 bucket. To enhance our security posture, we're transitioning away from using AWS user credentials. This change will require updates to your configuration.
+
+## Previous Method
+
+Historically, the ManifestService required AWS credentials to be able to access the S3 bucket. These credentials were passed through a Kubernetes secret, which the service consumed.
+
+## New Method
+
+With the latest update, ManifestService will no longer look for AWS credentials in the configuration file. Instead, the service will rely on credentials mounted to the pod. This change is implemented to ensure an improved security environment for the service.
+
+### AWS EKS IRSA
+
+We will now be utilizing the AWS EKS Identity Roles for Service Accounts (IRSA). This approach automounts AWS role credentials to a pod based on an EKS service account. This update aims to streamline the credentialing process and further secure access to the AWS S3 bucket.
+
+**NOTE:** The use of AWS EKS IRSA is applicable if you're using AWS EKS.
+
+### Non-EKS Users
+
+For those not using AWS EKS, the method for mounting the credentials will need to change. The recommended way is to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as environment variables in the pod.
+
+In future iterations, we aim to include this feature in the Helm chart deployment to simplify the process.
+
+## Action Required
+
+Please update your setup to comply with this new security update. Should you face any issues or have any queries regarding this update, please feel free to reach out. We appreciate your understanding as we work together to enhance our security posture.

--- a/manifestservice/api.py
+++ b/manifestservice/api.py
@@ -37,15 +37,7 @@ def create_app():
     app.config["OIDC_ISSUER"] = "https://%s/user" % config_dict["hostname"]
     app.config["MANIFEST_BUCKET_NAME"] = config_dict["manifest_bucket_name"]
 
-    app.config["AWS_ACCESS_KEY_ID"] = config_dict["aws_access_key_id"].strip()
-    app.config["AWS_SECRET_ACCESS_KEY"] = config_dict["aws_secret_access_key"].strip()
-
-    os.environ["AWS_ACCESS_KEY_ID"] = config_dict["aws_access_key_id"].strip()
-    os.environ["AWS_SECRET_ACCESS_KEY"] = config_dict["aws_secret_access_key"].strip()
-
     required_config_variables = [
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_ACCESS_KEY_ID",
         "OIDC_ISSUER",
         "MANIFEST_BUCKET_NAME",
     ]

--- a/manifestservice/manifests/__init__.py
+++ b/manifestservice/manifests/__init__.py
@@ -210,8 +210,6 @@ def _add_manifest_to_bucket(current_token, manifest_json):
     """
     session = boto3.Session(
         region_name="us-east-1",
-        aws_access_key_id=app.config["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=app.config["AWS_SECRET_ACCESS_KEY"],
     )
     s3 = session.resource("s3")
 
@@ -250,8 +248,6 @@ def _add_GUID_to_bucket(current_token, GUID):
     """
     session = boto3.Session(
         region_name="us-east-1",
-        aws_access_key_id=app.config["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=app.config["AWS_SECRET_ACCESS_KEY"],
     )
     s3 = session.resource("s3")
 
@@ -361,8 +357,6 @@ def _list_files_in_bucket(bucket_name, folder):
     """
     session = boto3.Session(
         region_name="us-east-1",
-        aws_access_key_id=app.config["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=app.config["AWS_SECRET_ACCESS_KEY"],
     )
     s3 = session.resource("s3")
 
@@ -408,8 +402,6 @@ def _get_file_contents(bucket_name, folder, filename):
     """
     client = boto3.client(
         "s3",
-        aws_access_key_id=app.config["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=app.config["AWS_SECRET_ACCESS_KEY"],
     )
     obj = client.get_object(Bucket=bucket_name, Key=folder + "/" + filename)
     as_bytes = obj["Body"].read()


### PR DESCRIPTION
### New Features
Use EKS IAM service account tied to a role instead of AWS IAM user.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- ManifestService does not expect `aws_access_key_id` and `aws_secret_access_key` settings anymore. Instead, the service relies on AWS EKS IRSA credentials mounted to the pod. See https://github.com/uc-cdis/manifestservice/blob/master/docs/credentials_breaking_change.md for more details