### PR TITLE
Chore/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Create a cohort GUID in the user's folder:
 Lists a user's exported metadata objects:
 
     GET /metadata
-    Returns: { "metadata" : [ { "filename" : "manifest-2024-06-13T17-14-46.026593.json", "last_modified" : "2024-06-13 17:14:47" }, ... ] }
+    Returns: { "metadata" : [ { "filename" : "metadata-2024-06-13T17-14-46.026593.json", "last_modified" : "2024-06-13 17:14:47" }, ... ] }
 
 Create an exported metadata object in the user's folder:
 
     POST /metadata
     Post body: { "some_metadata_key": "some_metadata_value" }
-    Returns: { "filename" : "manifest-2024-06-13T17-14-46.026593.json" }
+    Returns: { "filename" : "metadata-2024-06-13T17-14-46.026593.json" }
 
 Read the contents of an exported metadata object file in the user's folder:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Manifest Service
+
 ### Overview
 This service handles reading from and writing to a user's s3 folder containing their manifests. A manifest is a JSON file that lists records a researcher may be interested in analyzing. This service stores a manifest to a user folder in an s3 bucket and delivers it for later use, such as when the researcher wants to mount the manifest in their workspace. If the "prefix" config variable is set, user folders will be stored in a directory of that name within the s3 bucket.
 
@@ -48,10 +49,29 @@ Create a cohort GUID in the user's folder:
     Post body: { "guid": "5183a350-9d56-4084-8a03-6471cafeb7fe" }
     Returns: { "filename" : "5183a350-9d56-4084-8a03-6471cafeb7fe" }
 
+Lists a user's exported metadata objects:
+
+    GET /metadata
+    Returns: { "metadata" : [ { "filename" : "manifest-2024-06-13T17-14-46.026593.json", "last_modified" : "2024-06-13 17:14:47" }, ... ] }
+
+Create an exported metadata object in the user's folder:
+
+    POST /metadata
+    Post body: { "some_metadata_key": "some_metadata_value" }
+    Returns: { "filename" : "manifest-2024-06-13T17-14-46.026593.json" }
+
+Read the contents of an exported metadata object file in the user's folder:
+
+    GET /metadata/<filename.json>
+    Returns: { "body" : "the-body-of-the-exported-metadata-object-file-as-a-string" }
+
 On failure, the above endpoints all return JSON in the form
 
     { "error" : "error-message" }
 
+### OpenAPI spec
+
+The [OpenAPI](https://github.com/OAI/OpenAPI-Specification)/[Swagger 2.0](https://swagger.io/) specification of a service is stored in its `swagger.yaml` and can be visualized [here](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/manifestservice/master/openapi/swagger.yaml).
 
 ### Running the service locally
 If you want to run this service locally, fill out the config.json file with the correct values and then run:

--- a/manifestservice/manifests/__init__.py
+++ b/manifestservice/manifests/__init__.py
@@ -273,7 +273,7 @@ def put_metadata():
     responses:
         200:
             description: Success
-            example: '({ "filename": "5183a350-9d56-4084-8a03-6471cafeb7fe" }, 200)'
+            example: '({ "filename": "metadata-2024-06-13T17-14-46.026593.json" }, 200)'
         403:
             description: Unauthorized
             example: '({ "error": "<error-message>" }, 403)'

--- a/manifestservice/manifests/__init__.py
+++ b/manifestservice/manifests/__init__.py
@@ -452,7 +452,7 @@ def _generate_unique_filename(
 
 
 def _generate_unique_filename_with_timestamp_and_increment(
-    timestamp, users_existing_manifest_files, file_type
+    timestamp, users_existing_manifest_files, file_type="manifest"
 ):
     """
     A helper function for _generate_unique_manifest_filename(), which facilitates unit testing.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,6 +1,6 @@
 # OpenAPI spec
 
-The [OpenAPI](https://github.com/OAI/OpenAPI-Specification)/[Swagger 2.0](https://swagger.io/) specification of a service is stored in its `swagger.yaml` file. It can be visualized using the Swagger UI at `http://petstore.swagger.io/?url=<swagger.yaml raw URL>`. For example, the documentation found in this folder can be visualized [here](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/service-template/master/openapi/swagger.yaml).
+The [OpenAPI](https://github.com/OAI/OpenAPI-Specification)/[Swagger 2.0](https://swagger.io/) specification of a service is stored in its `swagger.yaml` file. It can be visualized using the Swagger UI at `http://petstore.swagger.io/?url=<swagger.yaml raw URL>`. For example, the documentation found in this folder can be visualized [here](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/manifestservice/master/openapi/swagger.yaml).
 
 # To generate the documentation
 

--- a/openapi/swagger.yaml
+++ b/openapi/swagger.yaml
@@ -83,4 +83,46 @@ paths:
         '403':
           description: Unauthorized
       summary: Returns the requested manifest file from the user's folder.
+  /metadata:
+    get:
+      responses:
+        '200':
+          description: Success
+        '403':
+          description: Unauthorized
+      summary: List all exported metadata objects associated with user
+    post:
+      responses:
+        '200':
+          description: Success
+          example: '({ "filename": "5183a350-9d56-4084-8a03-6471cafeb7fe" }, 200)'
+        '400':
+          description: Bad GUID format
+          example: '({ "error": "<error-message>" }, 400)'
+        '403':
+          description: Unauthorized
+          example: '({ "error": "<error-message>" }, 403)'
+      summary: Create an exported metadata object
+    put:
+      responses:
+        '200':
+          description: Success
+          example: '({ "filename": "5183a350-9d56-4084-8a03-6471cafeb7fe" }, 200)'
+        '400':
+          description: Bad GUID format
+          example: '({ "error": "<error-message>" }, 400)'
+        '403':
+          description: Unauthorized
+          example: '({ "error": "<error-message>" }, 403)'
+      summary: Create an exported metadata object
+  /metadata/{file_name}:
+    get:
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad request format
+        '403':
+          description: Unauthorized
+      summary: List all exported metadata objects associated with user
 swagger: '2.0'

--- a/openapi/swagger.yaml
+++ b/openapi/swagger.yaml
@@ -95,7 +95,7 @@ paths:
       responses:
         '200':
           description: Success
-          example: '({ "filename": "5183a350-9d56-4084-8a03-6471cafeb7fe" }, 200)'
+          example: '({ "filename": "metadata-2024-06-13T17-14-46.026593.json" }, 200)'
         '400':
           description: Bad GUID format
           example: '({ "error": "<error-message>" }, 400)'
@@ -107,7 +107,7 @@ paths:
       responses:
         '200':
           description: Success
-          example: '({ "filename": "5183a350-9d56-4084-8a03-6471cafeb7fe" }, 200)'
+          example: '({ "filename": "metadata-2024-06-13T17-14-46.026593.json" }, 200)'
         '400':
           description: Bad GUID format
           example: '({ "error": "<error-message>" }, 400)'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def mocks(mocker):
                     {"filename": "manifest-a-b-c.json"},
                 ],
                 "cohorts": [{"filename": "18e32c12-a053-4ac5-90a5-f01f70b5c2be"}],
-                "metadata": [{"filename": "manifest-2024-04-26T18-59-21.226440.json"}],
+                "metadata": [{"filename": "metadata-2024-04-26T18-59-21.226440.json"}],
             },
             True,
         ),

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,5 +1,17 @@
 import json as json_utils
+from manifestservice import manifests
 
+def test_generate_unique_metadata_filename_basic_date_generation():
+    """
+    Tests that the _generate_unique_filename_with_timestamp_and_increment() function
+    generates a unique filename for metadata file.
+    """
+    timestamp = "a-b-c"
+    users_existing_metadata_files = []
+    filename = manifests._generate_unique_filename_with_timestamp_and_increment(
+        timestamp, users_existing_metadata_files, file_type="metadata"
+    )
+    assert filename == "metadata-a-b-c.json"
 
 def test_POST_successful_metadata_add(client, mocks):
     """

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -68,7 +68,7 @@ def test_GET_metadata(client, mocks):
     assert len(metadata_returned) == 1
     # From the s3 mock
     assert (
-        metadata_returned[0]["filename"] == "manifest-2024-04-26T18-59-21.226440.json"
+        metadata_returned[0]["filename"] == "metadata-2024-04-26T18-59-21.226440.json"
     )
 
 


### PR DESCRIPTION
### Improvements
- change exported metadata filenames to `metadata-<timestamp>.json`
- updated README and OpenAPI docs with regards to the new `/metadata` API endpoints