### PR TITLE
PPS-3748: pin mistune >=3.3.0  (CVE-2026-49851)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -905,14 +905,14 @@ files = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.3"
 description = "A sane and fast Markdown parser with useful plugins and renderers"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048"},
-    {file = "mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28"},
+    {file = "mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7"},
+    {file = "mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477"},
 ]
 
 [[package]]
@@ -1441,4 +1441,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "25f8eb2bd5029ca6f28d92847f4cd01930726325adb91320e43e59d87acc438b"
+content-hash = "303da0cdbfed164be87f10b59222e7d295a5f848f15d8005a813ef6b73f8d1d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ cdiserrors = ">=1.0.0"
 cdislogging = ">=1.1.1"
 pyyaml = ">=6.0.1"
 flasgger = ">=0.9.7.1"
+mistune = ">=3.3.0" # CVE-2026-49851 (via flasgger)
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=6.2.3"


### PR DESCRIPTION

https://ctds-planx.atlassian.net/browse/PPS-3748 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates
- pin mistune >=3.3.0 to resolve CVE-2026-49851 (ReDoS via flasgger)

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
